### PR TITLE
Fix for 12th key not reporting

### DIFF
--- a/src/macropad.ts
+++ b/src/macropad.ts
@@ -197,7 +197,7 @@ export class MacroPad extends EventEmitter {
     const buttons = new Set<number>()
     for (let i=1; i < report.length; i++) {
       const button = report[i]
-      if (button <= 0 || button >= MACROPAD_KEY_COUNT)
+      if (button <= 0 || button > MACROPAD_KEY_COUNT)
         continue
 
       buttons.add(button)


### PR DESCRIPTION
Firmware sends key presses for all keys, but the JS code has a off-by-one error making it ignore the 12th button.

Fix the comparison so that all keys are reported.